### PR TITLE
Fix the synopsis's title

### DIFF
--- a/lib/Dancer/Plugin/Swig.pm
+++ b/lib/Dancer/Plugin/Swig.pm
@@ -40,6 +40,7 @@ register_plugin;
 Dancer::Plugin::Swig - A plugin for swig client
 
 =head1 SYNOPSIS
+
 In your Dancer config.yml:
 
   plugins:


### PR DESCRIPTION
No CR between the first line and the '=head' line meant that
it was merged to the title
